### PR TITLE
前回作成時の参加者を設定できるようにするショートカット

### DIFF
--- a/components/tm-button.vue
+++ b/components/tm-button.vue
@@ -1,13 +1,6 @@
 <template>
-  <button
-    :type="type"
-    :appearance="appearance"
-    :kind="kind"
-    :class="[a,k]"
-    class="Button"
-    @click="onClick"
-  >
-    <slot/>
+  <button :type="type" :appearance="appearance" :kind="kind" :class="[a, k]" class="Button" @click="onClick">
+    <slot />
   </button>
 </template>
 
@@ -15,7 +8,7 @@
 import Vue from 'vue';
 const appearances = ['text', 'button'];
 const types = ['button', 'submit'];
-const kinds = ['normal', 'primary', 'disabled'];
+const kinds = ['normal', 'primary', 'modest', 'disabled'];
 
 export default Vue.extend({
   props: {
@@ -72,13 +65,12 @@ export default Vue.extend({
 }
 
 .Button.-button {
-  height: 48px;
-  padding: 0 16px;
+  padding: 0.75em 16px;
   border: 2px solid transparent;
   border-radius: 100em;
   background-color: transparent;
   text-align: center;
-  line-height: 48px;
+  line-height: 1.1;
   font-weight: bold;
   transition: border-color 300ms ease-in-out, box-shadow 300ms ease-in-out;
   will-change: border-color, box-shadow;
@@ -101,6 +93,7 @@ export default Vue.extend({
   border-color: #d3ccc9;
   box-shadow: 0 0 0 3px #5dc0f6;
 }
+
 .Button.-button.-primary {
   color: #2e282a;
   border: 2px solid #3de884;
@@ -111,10 +104,25 @@ export default Vue.extend({
   border-color: #099f47;
 }
 
-.Button.-button.-primary:active {
+.Button.-button.-primary:focus {
+  border-color: #099f47;
+  box-shadow: 0 0 0 3px #5dc0f6;
 }
 
-.Button.-button.-primary:focus {
+.Button.-button.-modest {
+  border-radius: 0;
+  padding: 0.5em 0;
+  color: #099f47;
+  border: 0;
+  background-color: transparent;
+  font-size: small;
+}
+
+.Button.-button.-modest:hover {
+  border: 0;
+}
+
+.Button.-button.-modest:focus {
   border-color: #099f47;
   box-shadow: 0 0 0 3px #5dc0f6;
 }

--- a/components/tm-input.vue
+++ b/components/tm-input.vue
@@ -12,7 +12,7 @@
       :readonly="readonly"
       class="Input-field"
       @input="onInput"
-    >
+    />
     <textarea
       v-if="type === 'textarea'"
       :value="value"

--- a/components/tm-link.vue
+++ b/components/tm-link.vue
@@ -1,6 +1,6 @@
 <template>
-  <nuxt-link :to="to" :appearance="appearance" :kind="kind" :class="[a,k]" class="Link">
-    <slot/>
+  <nuxt-link :to="to" :appearance="appearance" :kind="kind" :class="[a, k]" class="Link">
+    <slot />
   </nuxt-link>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app">
-    <nuxt/>
+    <nuxt />
   </div>
 </template>
 

--- a/lib/tolymer_grpc_web_pb.js
+++ b/lib/tolymer_grpc_web_pb.js
@@ -6,15 +6,12 @@
 
 // GENERATED CODE -- DO NOT EDIT!
 
-
-
 const grpc = {};
 grpc.web = require('grpc-web');
 
+var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 
-var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js')
-
-var google_protobuf_field_mask_pb = require('google-protobuf/google/protobuf/field_mask_pb.js')
+var google_protobuf_field_mask_pb = require('google-protobuf/google/protobuf/field_mask_pb.js');
 const proto = {};
 proto.tolymer = {};
 proto.tolymer.v1 = require('./tolymer_pb.js');
@@ -27,8 +24,7 @@ proto.tolymer.v1 = require('./tolymer_pb.js');
  * @struct
  * @final
  */
-proto.tolymer.v1.EventsClient =
-    function(hostname, credentials, options) {
+proto.tolymer.v1.EventsClient = function(hostname, credentials, options) {
   if (!options) options = {};
   options['format'] = 'text';
 
@@ -54,7 +50,6 @@ proto.tolymer.v1.EventsClient =
   this.options_ = options;
 };
 
-
 /**
  * @param {string} hostname
  * @param {?Object} credentials
@@ -63,19 +58,15 @@ proto.tolymer.v1.EventsClient =
  * @struct
  * @final
  */
-proto.tolymer.v1.EventsPromiseClient =
-    function(hostname, credentials, options) {
+proto.tolymer.v1.EventsPromiseClient = function(hostname, credentials, options) {
   if (!options) options = {};
   options['format'] = 'text';
 
   /**
    * @private @const {!proto.tolymer.v1.EventsClient} The delegate callback based client
    */
-  this.delegateClient_ = new proto.tolymer.v1.EventsClient(
-      hostname, credentials, options);
-
+  this.delegateClient_ = new proto.tolymer.v1.EventsClient(hostname, credentials, options);
 };
-
 
 /**
  * @const
@@ -92,7 +83,6 @@ const methodInfo_Events_GetEvent = new grpc.web.AbstractClientBase.MethodInfo(
   proto.tolymer.v1.Event.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.GetEventRequest} request The
  *     request proto
@@ -103,16 +93,15 @@ const methodInfo_Events_GetEvent = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Event>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.getEvent =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/GetEvent',
-      request,
-      metadata || {},
-      methodInfo_Events_GetEvent,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.getEvent = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/GetEvent',
+    request,
+    metadata || {},
+    methodInfo_Events_GetEvent,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.GetEventRequest} request The
@@ -122,17 +111,14 @@ proto.tolymer.v1.EventsClient.prototype.getEvent =
  * @return {!Promise<!proto.tolymer.v1.Event>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.getEvent =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.getEvent = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.getEvent(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.getEvent(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -149,7 +135,6 @@ const methodInfo_Events_CreateEvent = new grpc.web.AbstractClientBase.MethodInfo
   proto.tolymer.v1.Event.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.CreateEventRequest} request The
  *     request proto
@@ -160,16 +145,15 @@ const methodInfo_Events_CreateEvent = new grpc.web.AbstractClientBase.MethodInfo
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Event>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.createEvent =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/CreateEvent',
-      request,
-      metadata || {},
-      methodInfo_Events_CreateEvent,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.createEvent = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/CreateEvent',
+    request,
+    metadata || {},
+    methodInfo_Events_CreateEvent,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.CreateEventRequest} request The
@@ -179,17 +163,14 @@ proto.tolymer.v1.EventsClient.prototype.createEvent =
  * @return {!Promise<!proto.tolymer.v1.Event>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.createEvent =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.createEvent = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.createEvent(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.createEvent(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -206,7 +187,6 @@ const methodInfo_Events_UpdateEvent = new grpc.web.AbstractClientBase.MethodInfo
   proto.tolymer.v1.Event.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.UpdateEventRequest} request The
  *     request proto
@@ -217,16 +197,15 @@ const methodInfo_Events_UpdateEvent = new grpc.web.AbstractClientBase.MethodInfo
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Event>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.updateEvent =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/UpdateEvent',
-      request,
-      metadata || {},
-      methodInfo_Events_UpdateEvent,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.updateEvent = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/UpdateEvent',
+    request,
+    metadata || {},
+    methodInfo_Events_UpdateEvent,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.UpdateEventRequest} request The
@@ -236,17 +215,14 @@ proto.tolymer.v1.EventsClient.prototype.updateEvent =
  * @return {!Promise<!proto.tolymer.v1.Event>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.updateEvent =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.updateEvent = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.updateEvent(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.updateEvent(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -263,7 +239,6 @@ const methodInfo_Events_UpdateParticipants = new grpc.web.AbstractClientBase.Met
   google_protobuf_empty_pb.Empty.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.UpdateParticipantsRequest} request The
  *     request proto
@@ -274,16 +249,15 @@ const methodInfo_Events_UpdateParticipants = new grpc.web.AbstractClientBase.Met
  * @return {!grpc.web.ClientReadableStream<!proto.google.protobuf.Empty>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.updateParticipants =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/UpdateParticipants',
-      request,
-      metadata || {},
-      methodInfo_Events_UpdateParticipants,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.updateParticipants = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/UpdateParticipants',
+    request,
+    metadata || {},
+    methodInfo_Events_UpdateParticipants,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.UpdateParticipantsRequest} request The
@@ -293,17 +267,14 @@ proto.tolymer.v1.EventsClient.prototype.updateParticipants =
  * @return {!Promise<!proto.google.protobuf.Empty>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.updateParticipants =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.updateParticipants = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.updateParticipants(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.updateParticipants(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -320,7 +291,6 @@ const methodInfo_Events_CreateGame = new grpc.web.AbstractClientBase.MethodInfo(
   proto.tolymer.v1.Game.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.CreateGameRequest} request The
  *     request proto
@@ -331,16 +301,15 @@ const methodInfo_Events_CreateGame = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Game>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.createGame =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/CreateGame',
-      request,
-      metadata || {},
-      methodInfo_Events_CreateGame,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.createGame = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/CreateGame',
+    request,
+    metadata || {},
+    methodInfo_Events_CreateGame,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.CreateGameRequest} request The
@@ -350,17 +319,14 @@ proto.tolymer.v1.EventsClient.prototype.createGame =
  * @return {!Promise<!proto.tolymer.v1.Game>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.createGame =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.createGame = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.createGame(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.createGame(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -377,7 +343,6 @@ const methodInfo_Events_UpdateGame = new grpc.web.AbstractClientBase.MethodInfo(
   proto.tolymer.v1.Game.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.UpdateGameRequest} request The
  *     request proto
@@ -388,16 +353,15 @@ const methodInfo_Events_UpdateGame = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Game>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.updateGame =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/UpdateGame',
-      request,
-      metadata || {},
-      methodInfo_Events_UpdateGame,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.updateGame = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/UpdateGame',
+    request,
+    metadata || {},
+    methodInfo_Events_UpdateGame,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.UpdateGameRequest} request The
@@ -407,17 +371,14 @@ proto.tolymer.v1.EventsClient.prototype.updateGame =
  * @return {!Promise<!proto.tolymer.v1.Game>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.updateGame =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.updateGame = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.updateGame(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.updateGame(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -434,7 +395,6 @@ const methodInfo_Events_DeleteGame = new grpc.web.AbstractClientBase.MethodInfo(
   google_protobuf_empty_pb.Empty.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.DeleteGameRequest} request The
  *     request proto
@@ -445,16 +405,15 @@ const methodInfo_Events_DeleteGame = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.google.protobuf.Empty>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.deleteGame =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/DeleteGame',
-      request,
-      metadata || {},
-      methodInfo_Events_DeleteGame,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.deleteGame = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/DeleteGame',
+    request,
+    metadata || {},
+    methodInfo_Events_DeleteGame,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.DeleteGameRequest} request The
@@ -464,17 +423,14 @@ proto.tolymer.v1.EventsClient.prototype.deleteGame =
  * @return {!Promise<!proto.google.protobuf.Empty>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.deleteGame =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.deleteGame = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.deleteGame(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.deleteGame(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -491,7 +447,6 @@ const methodInfo_Events_PostTip = new grpc.web.AbstractClientBase.MethodInfo(
   proto.tolymer.v1.Tip.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.PostTipRequest} request The
  *     request proto
@@ -502,16 +457,15 @@ const methodInfo_Events_PostTip = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.tolymer.v1.Tip>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.postTip =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/PostTip',
-      request,
-      metadata || {},
-      methodInfo_Events_PostTip,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.postTip = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/PostTip',
+    request,
+    metadata || {},
+    methodInfo_Events_PostTip,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.PostTipRequest} request The
@@ -521,17 +475,14 @@ proto.tolymer.v1.EventsClient.prototype.postTip =
  * @return {!Promise<!proto.tolymer.v1.Tip>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.postTip =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.postTip = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.postTip(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.postTip(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
-
 
 /**
  * @const
@@ -548,7 +499,6 @@ const methodInfo_Events_DeleteTip = new grpc.web.AbstractClientBase.MethodInfo(
   google_protobuf_empty_pb.Empty.deserializeBinary
 );
 
-
 /**
  * @param {!proto.tolymer.v1.DeleteTipRequest} request The
  *     request proto
@@ -559,16 +509,15 @@ const methodInfo_Events_DeleteTip = new grpc.web.AbstractClientBase.MethodInfo(
  * @return {!grpc.web.ClientReadableStream<!proto.google.protobuf.Empty>|undefined}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsClient.prototype.deleteTip =
-    function(request, metadata, callback) {
-  return this.client_.rpcCall(this.hostname_ +
-      '/tolymer.v1.Events/DeleteTip',
-      request,
-      metadata || {},
-      methodInfo_Events_DeleteTip,
-      callback);
+proto.tolymer.v1.EventsClient.prototype.deleteTip = function(request, metadata, callback) {
+  return this.client_.rpcCall(
+    this.hostname_ + '/tolymer.v1.Events/DeleteTip',
+    request,
+    metadata || {},
+    methodInfo_Events_DeleteTip,
+    callback
+  );
 };
-
 
 /**
  * @param {!proto.tolymer.v1.DeleteTipRequest} request The
@@ -578,17 +527,13 @@ proto.tolymer.v1.EventsClient.prototype.deleteTip =
  * @return {!Promise<!proto.google.protobuf.Empty>}
  *     The XHR Node Readable Stream
  */
-proto.tolymer.v1.EventsPromiseClient.prototype.deleteTip =
-    function(request, metadata) {
+proto.tolymer.v1.EventsPromiseClient.prototype.deleteTip = function(request, metadata) {
   var _this = this;
-  return new Promise(function (resolve, reject) {
-    _this.delegateClient_.deleteTip(
-      request, metadata, function (error, response) {
-        error ? reject(error) : resolve(response);
-      });
+  return new Promise(function(resolve, reject) {
+    _this.delegateClient_.deleteTip(request, metadata, function(error, response) {
+      error ? reject(error) : resolve(response);
+    });
   });
 };
 
-
 module.exports = proto.tolymer.v1;
-

--- a/lib/tolymer_pb.js
+++ b/lib/tolymer_pb.js
@@ -50,44 +50,42 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.GetEventRequest.displayName = 'proto.tolymer.v1.GetEventRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.GetEventRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.GetEventRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.GetEventRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.GetEventRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, "")
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.GetEventRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.GetEventRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.GetEventRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.GetEventRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, '')
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -96,10 +94,9 @@ proto.tolymer.v1.GetEventRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.GetEventRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.GetEventRequest;
+  var msg = new proto.tolymer.v1.GetEventRequest();
   return proto.tolymer.v1.GetEventRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -115,18 +112,17 @@ proto.tolymer.v1.GetEventRequest.deserializeBinaryFromReader = function(msg, rea
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -137,7 +133,6 @@ proto.tolymer.v1.GetEventRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.GetEventRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -150,29 +145,22 @@ proto.tolymer.v1.GetEventRequest.serializeBinaryToWriter = function(message, wri
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.GetEventRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.GetEventRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -198,46 +186,43 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.CreateEventRequest.repeatedFields_ = [2];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.CreateEventRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.CreateEventRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.CreateEventRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.CreateEventRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    description: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    participantsList: jspb.Message.getRepeatedField(msg, 2)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.CreateEventRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.CreateEventRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.CreateEventRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.CreateEventRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        description: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        participantsList: jspb.Message.getRepeatedField(msg, 2)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -246,10 +231,9 @@ proto.tolymer.v1.CreateEventRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.CreateEventRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.CreateEventRequest;
+  var msg = new proto.tolymer.v1.CreateEventRequest();
   return proto.tolymer.v1.CreateEventRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -265,22 +249,21 @@ proto.tolymer.v1.CreateEventRequest.deserializeBinaryFromReader = function(msg, 
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setDescription(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.addParticipants(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setDescription(value);
+        break;
+      case 2:
+        var value = /** @type {string} */ (reader.readString());
+        msg.addParticipants(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -291,7 +274,6 @@ proto.tolymer.v1.CreateEventRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.CreateEventRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -304,35 +286,26 @@ proto.tolymer.v1.CreateEventRequest.serializeBinaryToWriter = function(message, 
   var f = undefined;
   f = message.getDescription();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getParticipantsList();
   if (f.length > 0) {
-    writer.writeRepeatedString(
-      2,
-      f
-    );
+    writer.writeRepeatedString(2, f);
   }
 };
-
 
 /**
  * optional string description = 1;
  * @return {string}
  */
 proto.tolymer.v1.CreateEventRequest.prototype.getDescription = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.CreateEventRequest.prototype.setDescription = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
 
 /**
  * repeated string participants = 2;
@@ -342,12 +315,10 @@ proto.tolymer.v1.CreateEventRequest.prototype.getParticipantsList = function() {
   return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 2));
 };
 
-
 /** @param {!Array<string>} value */
 proto.tolymer.v1.CreateEventRequest.prototype.setParticipantsList = function(value) {
   jspb.Message.setField(this, 2, value || []);
 };
-
 
 /**
  * @param {!string} value
@@ -357,12 +328,9 @@ proto.tolymer.v1.CreateEventRequest.prototype.addParticipants = function(value, 
   jspb.Message.addToRepeatedField(this, 2, value, opt_index);
 };
 
-
 proto.tolymer.v1.CreateEventRequest.prototype.clearParticipantsList = function() {
   this.setParticipantsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -382,46 +350,44 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.UpdateEventRequest.displayName = 'proto.tolymer.v1.UpdateEventRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.UpdateEventRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.UpdateEventRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.UpdateEventRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.UpdateEventRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    description: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.UpdateEventRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.UpdateEventRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.UpdateEventRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.UpdateEventRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        description: jspb.Message.getFieldWithDefault(msg, 2, ''),
+        updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -430,10 +396,9 @@ proto.tolymer.v1.UpdateEventRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.UpdateEventRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.UpdateEventRequest;
+  var msg = new proto.tolymer.v1.UpdateEventRequest();
   return proto.tolymer.v1.UpdateEventRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -449,27 +414,26 @@ proto.tolymer.v1.UpdateEventRequest.deserializeBinaryFromReader = function(msg, 
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setDescription(value);
-      break;
-    case 3:
-      var value = new google_protobuf_field_mask_pb.FieldMask;
-      reader.readMessage(value,google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
-      msg.setUpdateMask(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setDescription(value);
+        break;
+      case 3:
+        var value = new google_protobuf_field_mask_pb.FieldMask();
+        reader.readMessage(value, google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
+        msg.setUpdateMask(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -480,7 +444,6 @@ proto.tolymer.v1.UpdateEventRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.UpdateEventRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -493,79 +456,64 @@ proto.tolymer.v1.UpdateEventRequest.serializeBinaryToWriter = function(message, 
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getDescription();
   if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
+    writer.writeString(2, f);
   }
   f = message.getUpdateMask();
   if (f != null) {
-    writer.writeMessage(
-      3,
-      f,
-      google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
-    );
+    writer.writeMessage(3, f, google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.UpdateEventRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateEventRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * optional string description = 2;
  * @return {string}
  */
 proto.tolymer.v1.UpdateEventRequest.prototype.getDescription = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateEventRequest.prototype.setDescription = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
 };
 
-
 /**
  * optional google.protobuf.FieldMask update_mask = 3;
  * @return {?proto.google.protobuf.FieldMask}
  */
 proto.tolymer.v1.UpdateEventRequest.prototype.getUpdateMask = function() {
-  return /** @type{?proto.google.protobuf.FieldMask} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 3));
+  return /** @type{?proto.google.protobuf.FieldMask} */ (jspb.Message.getWrapperField(
+    this,
+    google_protobuf_field_mask_pb.FieldMask,
+    3
+  ));
 };
-
 
 /** @param {?proto.google.protobuf.FieldMask|undefined} value */
 proto.tolymer.v1.UpdateEventRequest.prototype.setUpdateMask = function(value) {
   jspb.Message.setWrapperField(this, 3, value);
 };
 
-
 proto.tolymer.v1.UpdateEventRequest.prototype.clearUpdateMask = function() {
   this.setUpdateMask(undefined);
 };
-
 
 /**
  * Returns whether this field is set.
@@ -574,8 +522,6 @@ proto.tolymer.v1.UpdateEventRequest.prototype.clearUpdateMask = function() {
 proto.tolymer.v1.UpdateEventRequest.prototype.hasUpdateMask = function() {
   return jspb.Message.getField(this, 3) != null;
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -599,51 +545,51 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.tolymer.v1.UpdateParticipantsRequest.repeatedFields_ = [2,3,4];
-
-
+proto.tolymer.v1.UpdateParticipantsRequest.repeatedFields_ = [2, 3, 4];
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.UpdateParticipantsRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.UpdateParticipantsRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.UpdateParticipantsRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.UpdateParticipantsRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    renamingParticipantsList: jspb.Message.toObjectList(msg.getRenamingParticipantsList(),
-    proto.tolymer.v1.Participant.toObject, includeInstance),
-    addingNamesList: jspb.Message.getRepeatedField(msg, 3),
-    deletingIdsList: jspb.Message.getRepeatedField(msg, 4)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.UpdateParticipantsRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.UpdateParticipantsRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.UpdateParticipantsRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.UpdateParticipantsRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        renamingParticipantsList: jspb.Message.toObjectList(
+          msg.getRenamingParticipantsList(),
+          proto.tolymer.v1.Participant.toObject,
+          includeInstance
+        ),
+        addingNamesList: jspb.Message.getRepeatedField(msg, 3),
+        deletingIdsList: jspb.Message.getRepeatedField(msg, 4)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -652,10 +598,9 @@ proto.tolymer.v1.UpdateParticipantsRequest.toObject = function(includeInstance, 
  */
 proto.tolymer.v1.UpdateParticipantsRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.UpdateParticipantsRequest;
+  var msg = new proto.tolymer.v1.UpdateParticipantsRequest();
   return proto.tolymer.v1.UpdateParticipantsRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -671,31 +616,30 @@ proto.tolymer.v1.UpdateParticipantsRequest.deserializeBinaryFromReader = functio
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = new proto.tolymer.v1.Participant;
-      reader.readMessage(value,proto.tolymer.v1.Participant.deserializeBinaryFromReader);
-      msg.addRenamingParticipants(value);
-      break;
-    case 3:
-      var value = /** @type {string} */ (reader.readString());
-      msg.addAddingNames(value);
-      break;
-    case 4:
-      var value = /** @type {!Array<number>} */ (reader.readPackedInt64());
-      msg.setDeletingIdsList(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = new proto.tolymer.v1.Participant();
+        reader.readMessage(value, proto.tolymer.v1.Participant.deserializeBinaryFromReader);
+        msg.addRenamingParticipants(value);
+        break;
+      case 3:
+        var value = /** @type {string} */ (reader.readString());
+        msg.addAddingNames(value);
+        break;
+      case 4:
+        var value = /** @type {!Array<number>} */ (reader.readPackedInt64());
+        msg.setDeletingIdsList(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -706,7 +650,6 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.serializeBinary = function(
   proto.tolymer.v1.UpdateParticipantsRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -719,66 +662,51 @@ proto.tolymer.v1.UpdateParticipantsRequest.serializeBinaryToWriter = function(me
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getRenamingParticipantsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      2,
-      f,
-      proto.tolymer.v1.Participant.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(2, f, proto.tolymer.v1.Participant.serializeBinaryToWriter);
   }
   f = message.getAddingNamesList();
   if (f.length > 0) {
-    writer.writeRepeatedString(
-      3,
-      f
-    );
+    writer.writeRepeatedString(3, f);
   }
   f = message.getDeletingIdsList();
   if (f.length > 0) {
-    writer.writePackedInt64(
-      4,
-      f
-    );
+    writer.writePackedInt64(4, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * repeated Participant renaming_participants = 2;
  * @return {!Array<!proto.tolymer.v1.Participant>}
  */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.getRenamingParticipantsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.Participant>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.Participant, 2));
+  return /** @type{!Array<!proto.tolymer.v1.Participant>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.Participant,
+    2
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.Participant>} value */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.setRenamingParticipantsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.Participant=} opt_value
@@ -789,11 +717,9 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.addRenamingParticipants = f
   return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.tolymer.v1.Participant, opt_index);
 };
 
-
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.clearRenamingParticipantsList = function() {
   this.setRenamingParticipantsList([]);
 };
-
 
 /**
  * repeated string adding_names = 3;
@@ -803,12 +729,10 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.getAddingNamesList = functi
   return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 3));
 };
 
-
 /** @param {!Array<string>} value */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.setAddingNamesList = function(value) {
   jspb.Message.setField(this, 3, value || []);
 };
-
 
 /**
  * @param {!string} value
@@ -818,11 +742,9 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.addAddingNames = function(v
   jspb.Message.addToRepeatedField(this, 3, value, opt_index);
 };
 
-
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.clearAddingNamesList = function() {
   this.setAddingNamesList([]);
 };
-
 
 /**
  * repeated int64 deleting_ids = 4;
@@ -832,12 +754,10 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.getDeletingIdsList = functi
   return /** @type {!Array<number>} */ (jspb.Message.getRepeatedField(this, 4));
 };
 
-
 /** @param {!Array<number>} value */
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.setDeletingIdsList = function(value) {
   jspb.Message.setField(this, 4, value || []);
 };
-
 
 /**
  * @param {!number} value
@@ -847,12 +767,9 @@ proto.tolymer.v1.UpdateParticipantsRequest.prototype.addDeletingIds = function(v
   jspb.Message.addToRepeatedField(this, 4, value, opt_index);
 };
 
-
 proto.tolymer.v1.UpdateParticipantsRequest.prototype.clearDeletingIdsList = function() {
   this.setDeletingIdsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -872,45 +789,43 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.CreateParticipantRequest.displayName = 'proto.tolymer.v1.CreateParticipantRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.CreateParticipantRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.CreateParticipantRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.CreateParticipantRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.CreateParticipantRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    name: jspb.Message.getFieldWithDefault(msg, 2, "")
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.CreateParticipantRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.CreateParticipantRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.CreateParticipantRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.CreateParticipantRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        name: jspb.Message.getFieldWithDefault(msg, 2, '')
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -919,10 +834,9 @@ proto.tolymer.v1.CreateParticipantRequest.toObject = function(includeInstance, m
  */
 proto.tolymer.v1.CreateParticipantRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.CreateParticipantRequest;
+  var msg = new proto.tolymer.v1.CreateParticipantRequest();
   return proto.tolymer.v1.CreateParticipantRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -938,22 +852,21 @@ proto.tolymer.v1.CreateParticipantRequest.deserializeBinaryFromReader = function
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setName(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setName(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -964,7 +877,6 @@ proto.tolymer.v1.CreateParticipantRequest.prototype.serializeBinary = function()
   proto.tolymer.v1.CreateParticipantRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -977,51 +889,39 @@ proto.tolymer.v1.CreateParticipantRequest.serializeBinaryToWriter = function(mes
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getName();
   if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
+    writer.writeString(2, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.CreateParticipantRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.CreateParticipantRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * optional string name = 2;
  * @return {string}
  */
 proto.tolymer.v1.CreateParticipantRequest.prototype.getName = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.CreateParticipantRequest.prototype.setName = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -1041,47 +941,45 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.UpdateParticipantRequest.displayName = 'proto.tolymer.v1.UpdateParticipantRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.UpdateParticipantRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.UpdateParticipantRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.UpdateParticipantRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.UpdateParticipantRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    participantId: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    name: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.UpdateParticipantRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.UpdateParticipantRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.UpdateParticipantRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.UpdateParticipantRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        participantId: jspb.Message.getFieldWithDefault(msg, 2, 0),
+        name: jspb.Message.getFieldWithDefault(msg, 3, ''),
+        updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -1090,10 +988,9 @@ proto.tolymer.v1.UpdateParticipantRequest.toObject = function(includeInstance, m
  */
 proto.tolymer.v1.UpdateParticipantRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.UpdateParticipantRequest;
+  var msg = new proto.tolymer.v1.UpdateParticipantRequest();
   return proto.tolymer.v1.UpdateParticipantRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -1109,31 +1006,30 @@ proto.tolymer.v1.UpdateParticipantRequest.deserializeBinaryFromReader = function
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setParticipantId(value);
-      break;
-    case 3:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setName(value);
-      break;
-    case 4:
-      var value = new google_protobuf_field_mask_pb.FieldMask;
-      reader.readMessage(value,google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
-      msg.setUpdateMask(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setParticipantId(value);
+        break;
+      case 3:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setName(value);
+        break;
+      case 4:
+        var value = new google_protobuf_field_mask_pb.FieldMask();
+        reader.readMessage(value, google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
+        msg.setUpdateMask(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -1144,7 +1040,6 @@ proto.tolymer.v1.UpdateParticipantRequest.prototype.serializeBinary = function()
   proto.tolymer.v1.UpdateParticipantRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -1157,50 +1052,34 @@ proto.tolymer.v1.UpdateParticipantRequest.serializeBinaryToWriter = function(mes
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getParticipantId();
   if (f !== 0) {
-    writer.writeInt64(
-      2,
-      f
-    );
+    writer.writeInt64(2, f);
   }
   f = message.getName();
   if (f.length > 0) {
-    writer.writeString(
-      3,
-      f
-    );
+    writer.writeString(3, f);
   }
   f = message.getUpdateMask();
   if (f != null) {
-    writer.writeMessage(
-      4,
-      f,
-      google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
-    );
+    writer.writeMessage(4, f, google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
 
 /**
  * optional int64 participant_id = 2;
@@ -1210,48 +1089,44 @@ proto.tolymer.v1.UpdateParticipantRequest.prototype.getParticipantId = function(
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.setParticipantId = function(value) {
   jspb.Message.setProto3IntField(this, 2, value);
 };
-
 
 /**
  * optional string name = 3;
  * @return {string}
  */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.getName = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.setName = function(value) {
   jspb.Message.setProto3StringField(this, 3, value);
 };
 
-
 /**
  * optional google.protobuf.FieldMask update_mask = 4;
  * @return {?proto.google.protobuf.FieldMask}
  */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.getUpdateMask = function() {
-  return /** @type{?proto.google.protobuf.FieldMask} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 4));
+  return /** @type{?proto.google.protobuf.FieldMask} */ (jspb.Message.getWrapperField(
+    this,
+    google_protobuf_field_mask_pb.FieldMask,
+    4
+  ));
 };
-
 
 /** @param {?proto.google.protobuf.FieldMask|undefined} value */
 proto.tolymer.v1.UpdateParticipantRequest.prototype.setUpdateMask = function(value) {
   jspb.Message.setWrapperField(this, 4, value);
 };
 
-
 proto.tolymer.v1.UpdateParticipantRequest.prototype.clearUpdateMask = function() {
   this.setUpdateMask(undefined);
 };
-
 
 /**
  * Returns whether this field is set.
@@ -1260,8 +1135,6 @@ proto.tolymer.v1.UpdateParticipantRequest.prototype.clearUpdateMask = function()
 proto.tolymer.v1.UpdateParticipantRequest.prototype.hasUpdateMask = function() {
   return jspb.Message.getField(this, 4) != null;
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -1281,45 +1154,43 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.DeleteParticipantRequest.displayName = 'proto.tolymer.v1.DeleteParticipantRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.DeleteParticipantRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.DeleteParticipantRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.DeleteParticipantRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.DeleteParticipantRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    participantId: jspb.Message.getFieldWithDefault(msg, 2, 0)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.DeleteParticipantRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.DeleteParticipantRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.DeleteParticipantRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.DeleteParticipantRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        participantId: jspb.Message.getFieldWithDefault(msg, 2, 0)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -1328,10 +1199,9 @@ proto.tolymer.v1.DeleteParticipantRequest.toObject = function(includeInstance, m
  */
 proto.tolymer.v1.DeleteParticipantRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.DeleteParticipantRequest;
+  var msg = new proto.tolymer.v1.DeleteParticipantRequest();
   return proto.tolymer.v1.DeleteParticipantRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -1347,22 +1217,21 @@ proto.tolymer.v1.DeleteParticipantRequest.deserializeBinaryFromReader = function
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setParticipantId(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setParticipantId(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -1373,7 +1242,6 @@ proto.tolymer.v1.DeleteParticipantRequest.prototype.serializeBinary = function()
   proto.tolymer.v1.DeleteParticipantRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -1386,35 +1254,26 @@ proto.tolymer.v1.DeleteParticipantRequest.serializeBinaryToWriter = function(mes
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getParticipantId();
   if (f !== 0) {
-    writer.writeInt64(
-      2,
-      f
-    );
+    writer.writeInt64(2, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.DeleteParticipantRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.DeleteParticipantRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
 
 /**
  * optional int64 participant_id = 2;
@@ -1424,13 +1283,10 @@ proto.tolymer.v1.DeleteParticipantRequest.prototype.getParticipantId = function(
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.DeleteParticipantRequest.prototype.setParticipantId = function(value) {
   jspb.Message.setProto3IntField(this, 2, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -1456,47 +1312,47 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.CreateGameRequest.repeatedFields_ = [2];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.CreateGameRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.CreateGameRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.CreateGameRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.CreateGameRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    resultsList: jspb.Message.toObjectList(msg.getResultsList(),
-    proto.tolymer.v1.GameResult.toObject, includeInstance)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.CreateGameRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.CreateGameRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.CreateGameRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.CreateGameRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        resultsList: jspb.Message.toObjectList(
+          msg.getResultsList(),
+          proto.tolymer.v1.GameResult.toObject,
+          includeInstance
+        )
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -1505,10 +1361,9 @@ proto.tolymer.v1.CreateGameRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.CreateGameRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.CreateGameRequest;
+  var msg = new proto.tolymer.v1.CreateGameRequest();
   return proto.tolymer.v1.CreateGameRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -1524,23 +1379,22 @@ proto.tolymer.v1.CreateGameRequest.deserializeBinaryFromReader = function(msg, r
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = new proto.tolymer.v1.GameResult;
-      reader.readMessage(value,proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
-      msg.addResults(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = new proto.tolymer.v1.GameResult();
+        reader.readMessage(value, proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
+        msg.addResults(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -1551,7 +1405,6 @@ proto.tolymer.v1.CreateGameRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.CreateGameRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -1564,52 +1417,43 @@ proto.tolymer.v1.CreateGameRequest.serializeBinaryToWriter = function(message, w
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getResultsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      2,
-      f,
-      proto.tolymer.v1.GameResult.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(2, f, proto.tolymer.v1.GameResult.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.CreateGameRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.CreateGameRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * repeated GameResult results = 2;
  * @return {!Array<!proto.tolymer.v1.GameResult>}
  */
 proto.tolymer.v1.CreateGameRequest.prototype.getResultsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.GameResult, 2));
+  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.GameResult,
+    2
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.GameResult>} value */
 proto.tolymer.v1.CreateGameRequest.prototype.setResultsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.GameResult=} opt_value
@@ -1620,12 +1464,9 @@ proto.tolymer.v1.CreateGameRequest.prototype.addResults = function(opt_value, op
   return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.tolymer.v1.GameResult, opt_index);
 };
 
-
 proto.tolymer.v1.CreateGameRequest.prototype.clearResultsList = function() {
   this.setResultsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -1651,49 +1492,49 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.UpdateGameRequest.repeatedFields_ = [3];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.UpdateGameRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.UpdateGameRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.UpdateGameRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.UpdateGameRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    gameId: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    resultsList: jspb.Message.toObjectList(msg.getResultsList(),
-    proto.tolymer.v1.GameResult.toObject, includeInstance),
-    updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.UpdateGameRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.UpdateGameRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.UpdateGameRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.UpdateGameRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        gameId: jspb.Message.getFieldWithDefault(msg, 2, 0),
+        resultsList: jspb.Message.toObjectList(
+          msg.getResultsList(),
+          proto.tolymer.v1.GameResult.toObject,
+          includeInstance
+        ),
+        updateMask: (f = msg.getUpdateMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -1702,10 +1543,9 @@ proto.tolymer.v1.UpdateGameRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.UpdateGameRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.UpdateGameRequest;
+  var msg = new proto.tolymer.v1.UpdateGameRequest();
   return proto.tolymer.v1.UpdateGameRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -1721,32 +1561,31 @@ proto.tolymer.v1.UpdateGameRequest.deserializeBinaryFromReader = function(msg, r
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setGameId(value);
-      break;
-    case 3:
-      var value = new proto.tolymer.v1.GameResult;
-      reader.readMessage(value,proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
-      msg.addResults(value);
-      break;
-    case 4:
-      var value = new google_protobuf_field_mask_pb.FieldMask;
-      reader.readMessage(value,google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
-      msg.setUpdateMask(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setGameId(value);
+        break;
+      case 3:
+        var value = new proto.tolymer.v1.GameResult();
+        reader.readMessage(value, proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
+        msg.addResults(value);
+        break;
+      case 4:
+        var value = new google_protobuf_field_mask_pb.FieldMask();
+        reader.readMessage(value, google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
+        msg.setUpdateMask(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -1757,7 +1596,6 @@ proto.tolymer.v1.UpdateGameRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.UpdateGameRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -1770,51 +1608,34 @@ proto.tolymer.v1.UpdateGameRequest.serializeBinaryToWriter = function(message, w
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getGameId();
   if (f !== 0) {
-    writer.writeInt64(
-      2,
-      f
-    );
+    writer.writeInt64(2, f);
   }
   f = message.getResultsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      3,
-      f,
-      proto.tolymer.v1.GameResult.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(3, f, proto.tolymer.v1.GameResult.serializeBinaryToWriter);
   }
   f = message.getUpdateMask();
   if (f != null) {
-    writer.writeMessage(
-      4,
-      f,
-      google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
-    );
+    writer.writeMessage(4, f, google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.UpdateGameRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.UpdateGameRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
 
 /**
  * optional int64 game_id = 2;
@@ -1824,28 +1645,27 @@ proto.tolymer.v1.UpdateGameRequest.prototype.getGameId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.UpdateGameRequest.prototype.setGameId = function(value) {
   jspb.Message.setProto3IntField(this, 2, value);
 };
-
 
 /**
  * repeated GameResult results = 3;
  * @return {!Array<!proto.tolymer.v1.GameResult>}
  */
 proto.tolymer.v1.UpdateGameRequest.prototype.getResultsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.GameResult, 3));
+  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.GameResult,
+    3
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.GameResult>} value */
 proto.tolymer.v1.UpdateGameRequest.prototype.setResultsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.GameResult=} opt_value
@@ -1856,32 +1676,30 @@ proto.tolymer.v1.UpdateGameRequest.prototype.addResults = function(opt_value, op
   return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.tolymer.v1.GameResult, opt_index);
 };
 
-
 proto.tolymer.v1.UpdateGameRequest.prototype.clearResultsList = function() {
   this.setResultsList([]);
 };
-
 
 /**
  * optional google.protobuf.FieldMask update_mask = 4;
  * @return {?proto.google.protobuf.FieldMask}
  */
 proto.tolymer.v1.UpdateGameRequest.prototype.getUpdateMask = function() {
-  return /** @type{?proto.google.protobuf.FieldMask} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 4));
+  return /** @type{?proto.google.protobuf.FieldMask} */ (jspb.Message.getWrapperField(
+    this,
+    google_protobuf_field_mask_pb.FieldMask,
+    4
+  ));
 };
-
 
 /** @param {?proto.google.protobuf.FieldMask|undefined} value */
 proto.tolymer.v1.UpdateGameRequest.prototype.setUpdateMask = function(value) {
   jspb.Message.setWrapperField(this, 4, value);
 };
 
-
 proto.tolymer.v1.UpdateGameRequest.prototype.clearUpdateMask = function() {
   this.setUpdateMask(undefined);
 };
-
 
 /**
  * Returns whether this field is set.
@@ -1890,8 +1708,6 @@ proto.tolymer.v1.UpdateGameRequest.prototype.clearUpdateMask = function() {
 proto.tolymer.v1.UpdateGameRequest.prototype.hasUpdateMask = function() {
   return jspb.Message.getField(this, 4) != null;
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -1911,45 +1727,43 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.DeleteGameRequest.displayName = 'proto.tolymer.v1.DeleteGameRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.DeleteGameRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.DeleteGameRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.DeleteGameRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.DeleteGameRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    gameId: jspb.Message.getFieldWithDefault(msg, 2, 0)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.DeleteGameRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.DeleteGameRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.DeleteGameRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.DeleteGameRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        gameId: jspb.Message.getFieldWithDefault(msg, 2, 0)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -1958,10 +1772,9 @@ proto.tolymer.v1.DeleteGameRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.DeleteGameRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.DeleteGameRequest;
+  var msg = new proto.tolymer.v1.DeleteGameRequest();
   return proto.tolymer.v1.DeleteGameRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -1977,22 +1790,21 @@ proto.tolymer.v1.DeleteGameRequest.deserializeBinaryFromReader = function(msg, r
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setGameId(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setGameId(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2003,7 +1815,6 @@ proto.tolymer.v1.DeleteGameRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.DeleteGameRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -2016,35 +1827,26 @@ proto.tolymer.v1.DeleteGameRequest.serializeBinaryToWriter = function(message, w
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getGameId();
   if (f !== 0) {
-    writer.writeInt64(
-      2,
-      f
-    );
+    writer.writeInt64(2, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.DeleteGameRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.DeleteGameRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
 
 /**
  * optional int64 game_id = 2;
@@ -2054,13 +1856,10 @@ proto.tolymer.v1.DeleteGameRequest.prototype.getGameId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.DeleteGameRequest.prototype.setGameId = function(value) {
   jspb.Message.setProto3IntField(this, 2, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -2086,47 +1885,47 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.PostTipRequest.repeatedFields_ = [2];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.PostTipRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.PostTipRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.PostTipRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.PostTipRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    resultsList: jspb.Message.toObjectList(msg.getResultsList(),
-    proto.tolymer.v1.TipResult.toObject, includeInstance)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.PostTipRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.PostTipRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.PostTipRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.PostTipRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        resultsList: jspb.Message.toObjectList(
+          msg.getResultsList(),
+          proto.tolymer.v1.TipResult.toObject,
+          includeInstance
+        )
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -2135,10 +1934,9 @@ proto.tolymer.v1.PostTipRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.PostTipRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.PostTipRequest;
+  var msg = new proto.tolymer.v1.PostTipRequest();
   return proto.tolymer.v1.PostTipRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -2154,23 +1952,22 @@ proto.tolymer.v1.PostTipRequest.deserializeBinaryFromReader = function(msg, read
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    case 2:
-      var value = new proto.tolymer.v1.TipResult;
-      reader.readMessage(value,proto.tolymer.v1.TipResult.deserializeBinaryFromReader);
-      msg.addResults(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      case 2:
+        var value = new proto.tolymer.v1.TipResult();
+        reader.readMessage(value, proto.tolymer.v1.TipResult.deserializeBinaryFromReader);
+        msg.addResults(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2181,7 +1978,6 @@ proto.tolymer.v1.PostTipRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.PostTipRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -2194,52 +1990,43 @@ proto.tolymer.v1.PostTipRequest.serializeBinaryToWriter = function(message, writ
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getResultsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      2,
-      f,
-      proto.tolymer.v1.TipResult.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(2, f, proto.tolymer.v1.TipResult.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.PostTipRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.PostTipRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * repeated TipResult results = 2;
  * @return {!Array<!proto.tolymer.v1.TipResult>}
  */
 proto.tolymer.v1.PostTipRequest.prototype.getResultsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.TipResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.TipResult, 2));
+  return /** @type{!Array<!proto.tolymer.v1.TipResult>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.TipResult,
+    2
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.TipResult>} value */
 proto.tolymer.v1.PostTipRequest.prototype.setResultsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.TipResult=} opt_value
@@ -2250,12 +2037,9 @@ proto.tolymer.v1.PostTipRequest.prototype.addResults = function(opt_value, opt_i
   return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.tolymer.v1.TipResult, opt_index);
 };
 
-
 proto.tolymer.v1.PostTipRequest.prototype.clearResultsList = function() {
   this.setResultsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -2275,44 +2059,42 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.DeleteTipRequest.displayName = 'proto.tolymer.v1.DeleteTipRequest';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.DeleteTipRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.DeleteTipRequest.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.DeleteTipRequest} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.DeleteTipRequest.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    eventToken: jspb.Message.getFieldWithDefault(msg, 1, "")
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.DeleteTipRequest.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.DeleteTipRequest.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.DeleteTipRequest} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.DeleteTipRequest.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        eventToken: jspb.Message.getFieldWithDefault(msg, 1, '')
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -2321,10 +2103,9 @@ proto.tolymer.v1.DeleteTipRequest.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.DeleteTipRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.DeleteTipRequest;
+  var msg = new proto.tolymer.v1.DeleteTipRequest();
   return proto.tolymer.v1.DeleteTipRequest.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -2340,18 +2121,17 @@ proto.tolymer.v1.DeleteTipRequest.deserializeBinaryFromReader = function(msg, re
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setEventToken(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setEventToken(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2362,7 +2142,6 @@ proto.tolymer.v1.DeleteTipRequest.prototype.serializeBinary = function() {
   proto.tolymer.v1.DeleteTipRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -2375,29 +2154,22 @@ proto.tolymer.v1.DeleteTipRequest.serializeBinaryToWriter = function(message, wr
   var f = undefined;
   f = message.getEventToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
 };
-
 
 /**
  * optional string event_token = 1;
  * @return {string}
  */
 proto.tolymer.v1.DeleteTipRequest.prototype.getEventToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.DeleteTipRequest.prototype.setEventToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -2421,53 +2193,52 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.tolymer.v1.Event.repeatedFields_ = [3,4];
-
-
+proto.tolymer.v1.Event.repeatedFields_ = [3, 4];
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.Event.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.Event.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.Event} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.Event.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    token: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    description: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    participantsList: jspb.Message.toObjectList(msg.getParticipantsList(),
-    proto.tolymer.v1.Participant.toObject, includeInstance),
-    gamesList: jspb.Message.toObjectList(msg.getGamesList(),
-    proto.tolymer.v1.Game.toObject, includeInstance),
-    tip: (f = msg.getTip()) && proto.tolymer.v1.Tip.toObject(includeInstance, f)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.Event.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.Event.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.Event} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.Event.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        token: jspb.Message.getFieldWithDefault(msg, 1, ''),
+        description: jspb.Message.getFieldWithDefault(msg, 2, ''),
+        participantsList: jspb.Message.toObjectList(
+          msg.getParticipantsList(),
+          proto.tolymer.v1.Participant.toObject,
+          includeInstance
+        ),
+        gamesList: jspb.Message.toObjectList(msg.getGamesList(), proto.tolymer.v1.Game.toObject, includeInstance),
+        tip: (f = msg.getTip()) && proto.tolymer.v1.Tip.toObject(includeInstance, f)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -2476,10 +2247,9 @@ proto.tolymer.v1.Event.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.Event.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.Event;
+  var msg = new proto.tolymer.v1.Event();
   return proto.tolymer.v1.Event.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -2495,37 +2265,36 @@ proto.tolymer.v1.Event.deserializeBinaryFromReader = function(msg, reader) {
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setToken(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setDescription(value);
-      break;
-    case 3:
-      var value = new proto.tolymer.v1.Participant;
-      reader.readMessage(value,proto.tolymer.v1.Participant.deserializeBinaryFromReader);
-      msg.addParticipants(value);
-      break;
-    case 4:
-      var value = new proto.tolymer.v1.Game;
-      reader.readMessage(value,proto.tolymer.v1.Game.deserializeBinaryFromReader);
-      msg.addGames(value);
-      break;
-    case 5:
-      var value = new proto.tolymer.v1.Tip;
-      reader.readMessage(value,proto.tolymer.v1.Tip.deserializeBinaryFromReader);
-      msg.setTip(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setToken(value);
+        break;
+      case 2:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setDescription(value);
+        break;
+      case 3:
+        var value = new proto.tolymer.v1.Participant();
+        reader.readMessage(value, proto.tolymer.v1.Participant.deserializeBinaryFromReader);
+        msg.addParticipants(value);
+        break;
+      case 4:
+        var value = new proto.tolymer.v1.Game();
+        reader.readMessage(value, proto.tolymer.v1.Game.deserializeBinaryFromReader);
+        msg.addGames(value);
+        break;
+      case 5:
+        var value = new proto.tolymer.v1.Tip();
+        reader.readMessage(value, proto.tolymer.v1.Tip.deserializeBinaryFromReader);
+        msg.setTip(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2536,7 +2305,6 @@ proto.tolymer.v1.Event.prototype.serializeBinary = function() {
   proto.tolymer.v1.Event.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -2549,90 +2317,68 @@ proto.tolymer.v1.Event.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getToken();
   if (f.length > 0) {
-    writer.writeString(
-      1,
-      f
-    );
+    writer.writeString(1, f);
   }
   f = message.getDescription();
   if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
+    writer.writeString(2, f);
   }
   f = message.getParticipantsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      3,
-      f,
-      proto.tolymer.v1.Participant.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(3, f, proto.tolymer.v1.Participant.serializeBinaryToWriter);
   }
   f = message.getGamesList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      4,
-      f,
-      proto.tolymer.v1.Game.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(4, f, proto.tolymer.v1.Game.serializeBinaryToWriter);
   }
   f = message.getTip();
   if (f != null) {
-    writer.writeMessage(
-      5,
-      f,
-      proto.tolymer.v1.Tip.serializeBinaryToWriter
-    );
+    writer.writeMessage(5, f, proto.tolymer.v1.Tip.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional string token = 1;
  * @return {string}
  */
 proto.tolymer.v1.Event.prototype.getToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.Event.prototype.setToken = function(value) {
   jspb.Message.setProto3StringField(this, 1, value);
 };
 
-
 /**
  * optional string description = 2;
  * @return {string}
  */
 proto.tolymer.v1.Event.prototype.getDescription = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.Event.prototype.setDescription = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
 };
 
-
 /**
  * repeated Participant participants = 3;
  * @return {!Array<!proto.tolymer.v1.Participant>}
  */
 proto.tolymer.v1.Event.prototype.getParticipantsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.Participant>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.Participant, 3));
+  return /** @type{!Array<!proto.tolymer.v1.Participant>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.Participant,
+    3
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.Participant>} value */
 proto.tolymer.v1.Event.prototype.setParticipantsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.Participant=} opt_value
@@ -2643,27 +2389,26 @@ proto.tolymer.v1.Event.prototype.addParticipants = function(opt_value, opt_index
   return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.tolymer.v1.Participant, opt_index);
 };
 
-
 proto.tolymer.v1.Event.prototype.clearParticipantsList = function() {
   this.setParticipantsList([]);
 };
-
 
 /**
  * repeated Game games = 4;
  * @return {!Array<!proto.tolymer.v1.Game>}
  */
 proto.tolymer.v1.Event.prototype.getGamesList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.Game>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.Game, 4));
+  return /** @type{!Array<!proto.tolymer.v1.Game>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.Game,
+    4
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.Game>} value */
 proto.tolymer.v1.Event.prototype.setGamesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 4, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.Game=} opt_value
@@ -2674,32 +2419,26 @@ proto.tolymer.v1.Event.prototype.addGames = function(opt_value, opt_index) {
   return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.tolymer.v1.Game, opt_index);
 };
 
-
 proto.tolymer.v1.Event.prototype.clearGamesList = function() {
   this.setGamesList([]);
 };
-
 
 /**
  * optional Tip tip = 5;
  * @return {?proto.tolymer.v1.Tip}
  */
 proto.tolymer.v1.Event.prototype.getTip = function() {
-  return /** @type{?proto.tolymer.v1.Tip} */ (
-    jspb.Message.getWrapperField(this, proto.tolymer.v1.Tip, 5));
+  return /** @type{?proto.tolymer.v1.Tip} */ (jspb.Message.getWrapperField(this, proto.tolymer.v1.Tip, 5));
 };
-
 
 /** @param {?proto.tolymer.v1.Tip|undefined} value */
 proto.tolymer.v1.Event.prototype.setTip = function(value) {
   jspb.Message.setWrapperField(this, 5, value);
 };
 
-
 proto.tolymer.v1.Event.prototype.clearTip = function() {
   this.setTip(undefined);
 };
-
 
 /**
  * Returns whether this field is set.
@@ -2708,8 +2447,6 @@ proto.tolymer.v1.Event.prototype.clearTip = function() {
 proto.tolymer.v1.Event.prototype.hasTip = function() {
   return jspb.Message.getField(this, 5) != null;
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -2729,45 +2466,43 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.Participant.displayName = 'proto.tolymer.v1.Participant';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.Participant.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.Participant.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.Participant} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.Participant.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    name: jspb.Message.getFieldWithDefault(msg, 2, "")
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.Participant.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.Participant.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.Participant} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.Participant.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        id: jspb.Message.getFieldWithDefault(msg, 1, 0),
+        name: jspb.Message.getFieldWithDefault(msg, 2, '')
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -2776,10 +2511,9 @@ proto.tolymer.v1.Participant.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.Participant.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.Participant;
+  var msg = new proto.tolymer.v1.Participant();
   return proto.tolymer.v1.Participant.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -2795,22 +2529,21 @@ proto.tolymer.v1.Participant.deserializeBinaryFromReader = function(msg, reader)
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setId(value);
-      break;
-    case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setName(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setId(value);
+        break;
+      case 2:
+        var value = /** @type {string} */ (reader.readString());
+        msg.setName(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2821,7 +2554,6 @@ proto.tolymer.v1.Participant.prototype.serializeBinary = function() {
   proto.tolymer.v1.Participant.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -2834,20 +2566,13 @@ proto.tolymer.v1.Participant.serializeBinaryToWriter = function(message, writer)
   var f = undefined;
   f = message.getId();
   if (f !== 0) {
-    writer.writeInt64(
-      1,
-      f
-    );
+    writer.writeInt64(1, f);
   }
   f = message.getName();
   if (f.length > 0) {
-    writer.writeString(
-      2,
-      f
-    );
+    writer.writeString(2, f);
   }
 };
-
 
 /**
  * optional int64 id = 1;
@@ -2857,28 +2582,23 @@ proto.tolymer.v1.Participant.prototype.getId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.Participant.prototype.setId = function(value) {
   jspb.Message.setProto3IntField(this, 1, value);
 };
-
 
 /**
  * optional string name = 2;
  * @return {string}
  */
 proto.tolymer.v1.Participant.prototype.getName = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ''));
 };
-
 
 /** @param {string} value */
 proto.tolymer.v1.Participant.prototype.setName = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -2904,47 +2624,47 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.Game.repeatedFields_ = [2];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.Game.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.Game.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.Game} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.Game.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    resultsList: jspb.Message.toObjectList(msg.getResultsList(),
-    proto.tolymer.v1.GameResult.toObject, includeInstance)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.Game.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.Game.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.Game} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.Game.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        id: jspb.Message.getFieldWithDefault(msg, 1, 0),
+        resultsList: jspb.Message.toObjectList(
+          msg.getResultsList(),
+          proto.tolymer.v1.GameResult.toObject,
+          includeInstance
+        )
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -2953,10 +2673,9 @@ proto.tolymer.v1.Game.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.Game.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.Game;
+  var msg = new proto.tolymer.v1.Game();
   return proto.tolymer.v1.Game.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -2972,23 +2691,22 @@ proto.tolymer.v1.Game.deserializeBinaryFromReader = function(msg, reader) {
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setId(value);
-      break;
-    case 2:
-      var value = new proto.tolymer.v1.GameResult;
-      reader.readMessage(value,proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
-      msg.addResults(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setId(value);
+        break;
+      case 2:
+        var value = new proto.tolymer.v1.GameResult();
+        reader.readMessage(value, proto.tolymer.v1.GameResult.deserializeBinaryFromReader);
+        msg.addResults(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -2999,7 +2717,6 @@ proto.tolymer.v1.Game.prototype.serializeBinary = function() {
   proto.tolymer.v1.Game.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -3012,21 +2729,13 @@ proto.tolymer.v1.Game.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getId();
   if (f !== 0) {
-    writer.writeInt64(
-      1,
-      f
-    );
+    writer.writeInt64(1, f);
   }
   f = message.getResultsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      2,
-      f,
-      proto.tolymer.v1.GameResult.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(2, f, proto.tolymer.v1.GameResult.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * optional int64 id = 1;
@@ -3036,28 +2745,27 @@ proto.tolymer.v1.Game.prototype.getId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.Game.prototype.setId = function(value) {
   jspb.Message.setProto3IntField(this, 1, value);
 };
-
 
 /**
  * repeated GameResult results = 2;
  * @return {!Array<!proto.tolymer.v1.GameResult>}
  */
 proto.tolymer.v1.Game.prototype.getResultsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.GameResult, 2));
+  return /** @type{!Array<!proto.tolymer.v1.GameResult>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.GameResult,
+    2
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.GameResult>} value */
 proto.tolymer.v1.Game.prototype.setResultsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.GameResult=} opt_value
@@ -3068,12 +2776,9 @@ proto.tolymer.v1.Game.prototype.addResults = function(opt_value, opt_index) {
   return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.tolymer.v1.GameResult, opt_index);
 };
 
-
 proto.tolymer.v1.Game.prototype.clearResultsList = function() {
   this.setResultsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -3093,46 +2798,44 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.GameResult.displayName = 'proto.tolymer.v1.GameResult';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.GameResult.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.GameResult.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.GameResult} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.GameResult.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    participantId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    rank: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    score: +jspb.Message.getFieldWithDefault(msg, 3, 0.0)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.GameResult.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.GameResult.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.GameResult} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.GameResult.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        participantId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+        rank: jspb.Message.getFieldWithDefault(msg, 2, 0),
+        score: +jspb.Message.getFieldWithDefault(msg, 3, 0.0)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -3141,10 +2844,9 @@ proto.tolymer.v1.GameResult.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.GameResult.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.GameResult;
+  var msg = new proto.tolymer.v1.GameResult();
   return proto.tolymer.v1.GameResult.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -3160,26 +2862,25 @@ proto.tolymer.v1.GameResult.deserializeBinaryFromReader = function(msg, reader) 
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setParticipantId(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readInt32());
-      msg.setRank(value);
-      break;
-    case 3:
-      var value = /** @type {number} */ (reader.readDouble());
-      msg.setScore(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setParticipantId(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readInt32());
+        msg.setRank(value);
+        break;
+      case 3:
+        var value = /** @type {number} */ (reader.readDouble());
+        msg.setScore(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -3190,7 +2891,6 @@ proto.tolymer.v1.GameResult.prototype.serializeBinary = function() {
   proto.tolymer.v1.GameResult.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -3203,27 +2903,17 @@ proto.tolymer.v1.GameResult.serializeBinaryToWriter = function(message, writer) 
   var f = undefined;
   f = message.getParticipantId();
   if (f !== 0) {
-    writer.writeInt64(
-      1,
-      f
-    );
+    writer.writeInt64(1, f);
   }
   f = message.getRank();
   if (f !== 0) {
-    writer.writeInt32(
-      2,
-      f
-    );
+    writer.writeInt32(2, f);
   }
   f = message.getScore();
   if (f !== 0.0) {
-    writer.writeDouble(
-      3,
-      f
-    );
+    writer.writeDouble(3, f);
   }
 };
-
 
 /**
  * optional int64 participant_id = 1;
@@ -3233,12 +2923,10 @@ proto.tolymer.v1.GameResult.prototype.getParticipantId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.GameResult.prototype.setParticipantId = function(value) {
   jspb.Message.setProto3IntField(this, 1, value);
 };
-
 
 /**
  * optional int32 rank = 2;
@@ -3248,12 +2936,10 @@ proto.tolymer.v1.GameResult.prototype.getRank = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.GameResult.prototype.setRank = function(value) {
   jspb.Message.setProto3IntField(this, 2, value);
 };
-
 
 /**
  * optional double score = 3;
@@ -3263,13 +2949,10 @@ proto.tolymer.v1.GameResult.prototype.getScore = function() {
   return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 3, 0.0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.GameResult.prototype.setScore = function(value) {
   jspb.Message.setProto3FloatField(this, 3, value);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -3295,46 +2978,46 @@ if (goog.DEBUG && !COMPILED) {
  */
 proto.tolymer.v1.Tip.repeatedFields_ = [1];
 
-
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.Tip.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.Tip.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.Tip} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.Tip.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    resultsList: jspb.Message.toObjectList(msg.getResultsList(),
-    proto.tolymer.v1.TipResult.toObject, includeInstance)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.Tip.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.Tip.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.Tip} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.Tip.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        resultsList: jspb.Message.toObjectList(
+          msg.getResultsList(),
+          proto.tolymer.v1.TipResult.toObject,
+          includeInstance
+        )
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -3343,10 +3026,9 @@ proto.tolymer.v1.Tip.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.Tip.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.Tip;
+  var msg = new proto.tolymer.v1.Tip();
   return proto.tolymer.v1.Tip.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -3362,19 +3044,18 @@ proto.tolymer.v1.Tip.deserializeBinaryFromReader = function(msg, reader) {
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = new proto.tolymer.v1.TipResult;
-      reader.readMessage(value,proto.tolymer.v1.TipResult.deserializeBinaryFromReader);
-      msg.addResults(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = new proto.tolymer.v1.TipResult();
+        reader.readMessage(value, proto.tolymer.v1.TipResult.deserializeBinaryFromReader);
+        msg.addResults(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -3385,7 +3066,6 @@ proto.tolymer.v1.Tip.prototype.serializeBinary = function() {
   proto.tolymer.v1.Tip.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -3398,30 +3078,26 @@ proto.tolymer.v1.Tip.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getResultsList();
   if (f.length > 0) {
-    writer.writeRepeatedMessage(
-      1,
-      f,
-      proto.tolymer.v1.TipResult.serializeBinaryToWriter
-    );
+    writer.writeRepeatedMessage(1, f, proto.tolymer.v1.TipResult.serializeBinaryToWriter);
   }
 };
-
 
 /**
  * repeated TipResult results = 1;
  * @return {!Array<!proto.tolymer.v1.TipResult>}
  */
 proto.tolymer.v1.Tip.prototype.getResultsList = function() {
-  return /** @type{!Array<!proto.tolymer.v1.TipResult>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.tolymer.v1.TipResult, 1));
+  return /** @type{!Array<!proto.tolymer.v1.TipResult>} */ (jspb.Message.getRepeatedWrapperField(
+    this,
+    proto.tolymer.v1.TipResult,
+    1
+  ));
 };
-
 
 /** @param {!Array<!proto.tolymer.v1.TipResult>} value */
 proto.tolymer.v1.Tip.prototype.setResultsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 1, value);
 };
-
 
 /**
  * @param {!proto.tolymer.v1.TipResult=} opt_value
@@ -3432,12 +3108,9 @@ proto.tolymer.v1.Tip.prototype.addResults = function(opt_value, opt_index) {
   return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.tolymer.v1.TipResult, opt_index);
 };
 
-
 proto.tolymer.v1.Tip.prototype.clearResultsList = function() {
   this.setResultsList([]);
 };
-
-
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -3457,45 +3130,43 @@ if (goog.DEBUG && !COMPILED) {
   proto.tolymer.v1.TipResult.displayName = 'proto.tolymer.v1.TipResult';
 }
 
-
 if (jspb.Message.GENERATE_TO_OBJECT) {
-/**
- * Creates an object representation of this proto suitable for use in Soy templates.
- * Field names that are reserved in JavaScript and will be renamed to pb_name.
- * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
- * For the list of reserved names please see:
- *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
- * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
- *     for transitional soy proto support: http://goto/soy-param-migration
- * @return {!Object}
- */
-proto.tolymer.v1.TipResult.prototype.toObject = function(opt_includeInstance) {
-  return proto.tolymer.v1.TipResult.toObject(opt_includeInstance, this);
-};
-
-
-/**
- * Static version of the {@see toObject} method.
- * @param {boolean|undefined} includeInstance Whether to include the JSPB
- *     instance for transitional soy proto support:
- *     http://goto/soy-param-migration
- * @param {!proto.tolymer.v1.TipResult} msg The msg instance to transform.
- * @return {!Object}
- * @suppress {unusedLocalVariables} f is only used for nested messages
- */
-proto.tolymer.v1.TipResult.toObject = function(includeInstance, msg) {
-  var f, obj = {
-    participantId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    score: +jspb.Message.getFieldWithDefault(msg, 2, 0.0)
+  /**
+   * Creates an object representation of this proto suitable for use in Soy templates.
+   * Field names that are reserved in JavaScript and will be renamed to pb_name.
+   * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+   * For the list of reserved names please see:
+   *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+   * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+   *     for transitional soy proto support: http://goto/soy-param-migration
+   * @return {!Object}
+   */
+  proto.tolymer.v1.TipResult.prototype.toObject = function(opt_includeInstance) {
+    return proto.tolymer.v1.TipResult.toObject(opt_includeInstance, this);
   };
 
-  if (includeInstance) {
-    obj.$jspbMessageInstance = msg;
-  }
-  return obj;
-};
-}
+  /**
+   * Static version of the {@see toObject} method.
+   * @param {boolean|undefined} includeInstance Whether to include the JSPB
+   *     instance for transitional soy proto support:
+   *     http://goto/soy-param-migration
+   * @param {!proto.tolymer.v1.TipResult} msg The msg instance to transform.
+   * @return {!Object}
+   * @suppress {unusedLocalVariables} f is only used for nested messages
+   */
+  proto.tolymer.v1.TipResult.toObject = function(includeInstance, msg) {
+    var f,
+      obj = {
+        participantId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+        score: +jspb.Message.getFieldWithDefault(msg, 2, 0.0)
+      };
 
+    if (includeInstance) {
+      obj.$jspbMessageInstance = msg;
+    }
+    return obj;
+  };
+}
 
 /**
  * Deserializes binary data (in protobuf wire format).
@@ -3504,10 +3175,9 @@ proto.tolymer.v1.TipResult.toObject = function(includeInstance, msg) {
  */
 proto.tolymer.v1.TipResult.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.tolymer.v1.TipResult;
+  var msg = new proto.tolymer.v1.TipResult();
   return proto.tolymer.v1.TipResult.deserializeBinaryFromReader(msg, reader);
 };
-
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
@@ -3523,22 +3193,21 @@ proto.tolymer.v1.TipResult.deserializeBinaryFromReader = function(msg, reader) {
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = /** @type {number} */ (reader.readInt64());
-      msg.setParticipantId(value);
-      break;
-    case 2:
-      var value = /** @type {number} */ (reader.readDouble());
-      msg.setScore(value);
-      break;
-    default:
-      reader.skipField();
-      break;
+      case 1:
+        var value = /** @type {number} */ (reader.readInt64());
+        msg.setParticipantId(value);
+        break;
+      case 2:
+        var value = /** @type {number} */ (reader.readDouble());
+        msg.setScore(value);
+        break;
+      default:
+        reader.skipField();
+        break;
     }
   }
   return msg;
 };
-
 
 /**
  * Serializes the message to binary data (in protobuf wire format).
@@ -3549,7 +3218,6 @@ proto.tolymer.v1.TipResult.prototype.serializeBinary = function() {
   proto.tolymer.v1.TipResult.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
-
 
 /**
  * Serializes the given message to binary data (in protobuf wire
@@ -3562,20 +3230,13 @@ proto.tolymer.v1.TipResult.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getParticipantId();
   if (f !== 0) {
-    writer.writeInt64(
-      1,
-      f
-    );
+    writer.writeInt64(1, f);
   }
   f = message.getScore();
   if (f !== 0.0) {
-    writer.writeDouble(
-      2,
-      f
-    );
+    writer.writeDouble(2, f);
   }
 };
-
 
 /**
  * optional int64 participant_id = 1;
@@ -3585,12 +3246,10 @@ proto.tolymer.v1.TipResult.prototype.getParticipantId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.TipResult.prototype.setParticipantId = function(value) {
   jspb.Message.setProto3IntField(this, 1, value);
 };
-
 
 /**
  * optional double score = 2;
@@ -3600,11 +3259,9 @@ proto.tolymer.v1.TipResult.prototype.getScore = function() {
   return /** @type {number} */ (+jspb.Message.getFieldWithDefault(this, 2, 0.0));
 };
 
-
 /** @param {number} value */
 proto.tolymer.v1.TipResult.prototype.setScore = function(value) {
   jspb.Message.setProto3FloatField(this, 2, value);
 };
-
 
 goog.object.extend(exports, proto.tolymer.v1);

--- a/pages/events/_token/edit.vue
+++ b/pages/events/_token/edit.vue
@@ -14,7 +14,7 @@
         <h3>参加者</h3>
         <ul>
           <li v-for="(participant, i) in participants" :key="i">
-            <tm-input type="text" v-model="participant.name"/>
+            <tm-input type="text" v-model="participant.name" />
           </li>
         </ul>
         <div class="Form-item" style="margin-top: 25px">

--- a/pages/events/_token/table.vue
+++ b/pages/events/_token/table.vue
@@ -9,14 +9,10 @@
           </span>
           <ul v-if="showMenu">
             <li>
-              <nuxt-link :to="`/events/${token}/info`">
-                <i class="fas fa-info-circle"></i> イベント情報
-              </nuxt-link>
+              <nuxt-link :to="`/events/${token}/info`"> <i class="fas fa-info-circle"></i> イベント情報 </nuxt-link>
             </li>
             <li>
-              <nuxt-link to="/">
-                <i class="fas fa-plus-circle"></i> イベント作成
-              </nuxt-link>
+              <nuxt-link to="/"> <i class="fas fa-plus-circle"></i> イベント作成 </nuxt-link>
             </li>
           </ul>
         </div>
@@ -28,7 +24,7 @@
         <thead>
           <tr>
             <th class="gameNumberCol"></th>
-            <th v-for="(participant, i) in participants" :key="i">{{participant.name}}</th>
+            <th v-for="(participant, i) in participants" :key="i">{{ participant.name }}</th>
           </tr>
         </thead>
         <tbody>
@@ -40,31 +36,25 @@
             <th class="gameNumberCol">
               <nuxt-link :to="`/events/${token}/input?game_id=${game.id}`">{{ i + 1 }}</nuxt-link>
             </th>
-            <td
-              v-for="(score, j) in calcScores(game.resultsList)"
-              :key="j"
-              :class="getScoreColClass(score)"
-            >{{score}}</td>
+            <td v-for="(score, j) in calcScores(game.resultsList)" :key="j" :class="getScoreColClass(score)">
+              {{ score }}
+            </td>
           </tr>
           <tr v-if="tip" class="tipRow">
             <th class="gameNumberCol">
               <nuxt-link :to="`/events/${token}/input?type=tip`">T</nuxt-link>
             </th>
-            <td
-              v-for="(score, j) in calcScores(tip.resultsList)"
-              :key="j"
-              :class="getScoreColClass(score)"
-            >{{score}}</td>
+            <td v-for="(score, j) in calcScores(tip.resultsList)" :key="j" :class="getScoreColClass(score)">
+              {{ score }}
+            </td>
           </tr>
         </tbody>
         <tfoot v-if="games.length > 0 || tip">
           <tr class="totalRow">
             <th class="gameNumberCol"></th>
-            <td
-              v-for="(totalResult, i) in calcTotalResults()"
-              :key="i"
-              :class="getScoreColClass(totalResult)"
-            >{{totalResult}}</td>
+            <td v-for="(totalResult, i) in calcTotalResults()" :key="i" :class="getScoreColClass(totalResult)">
+              {{ totalResult }}
+            </td>
           </tr>
         </tfoot>
       </table>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,21 +1,30 @@
 <template>
   <main>
-    <div class="sticks"/>
+    <div class="sticks" />
     <h1 class="appname">tolymer</h1>
-    <div class="Form">
-      <h3>参加者（必須）</h3>
+    <section class="Form participants">
+      <header class="participants__header">
+        <h3>参加者（必須）</h3>
+        <tm-button
+          v-if="this.previousParticipants"
+          @click="setPreviousParticipants()"
+          class="participants__headerButton"
+          kind="modest"
+          >前回の参加者を設定</tm-button
+        >
+      </header>
       <ul>
         <li>
-          <tm-input type="text" v-model="participants[0]" placeholder="例: ほかむら"/>
+          <tm-input type="text" v-model="participants[0]" placeholder="例: ほかむら" />
         </li>
         <li>
-          <tm-input type="text" v-model="participants[1]" placeholder="例: たに"/>
+          <tm-input type="text" v-model="participants[1]" placeholder="例: たに" />
         </li>
         <li>
-          <tm-input type="text" v-model="participants[2]" placeholder="例: せんすい"/>
+          <tm-input type="text" v-model="participants[2]" placeholder="例: せんすい" />
         </li>
         <li>
-          <tm-input type="text" v-model="participants[3]" placeholder="例: たなか"/>
+          <tm-input type="text" v-model="participants[3]" placeholder="例: たなか" />
         </li>
       </ul>
       <div class="Form-item" style="margin-top: 30px">
@@ -33,7 +42,7 @@
       <div class="Form-action">
         <tm-button @click="submit()" class="Form-button" kind="primary">イベント作成</tm-button>
       </div>
-    </div>
+    </section>
   </main>
 </template>
 
@@ -52,15 +61,45 @@ export default Vue.extend({
   data() {
     return {
       description: '',
-      participants: []
+      participants: [] as string[],
+      previousParticipants: [] as string[]
     };
   },
+  mounted: function() {
+    this.previousParticipants = this.canUseStorage()
+      ? (JSON.parse(localStorage.getItem('participants') || '') as string[])
+      : [];
+  },
   methods: {
+    canUseStorage() {
+      try {
+        const key = '__test__';
+        localStorage.setItem(key, key);
+        localStorage.removeItem(key);
+
+        return true;
+      } catch (e) {
+        return false;
+      }
+    },
+    setPreviousParticipants() {
+      if (this.previousParticipants) {
+        try {
+          this.participants = this.previousParticipants;
+        } catch (e) {
+          return false;
+        }
+      }
+    },
     async submit() {
       const [err, event] = await createEvent({
         description: this.description,
         participants: this.participants
       });
+
+      if (this.canUseStorage()) {
+        localStorage.setItem('participants', JSON.stringify(this.participants));
+      }
 
       if (err) {
         alertError(err);
@@ -109,5 +148,15 @@ export default Vue.extend({
 
 .Form-button {
   min-width: 240px;
+}
+
+.participants__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.participants__headerButton {
+  margin-bottom: -0.5em;
 }
 </style>


### PR DESCRIPTION
# 概要
1. 前回のイベント作成時のリストをlocalStorageに保存する
2. keyがあればボタンが出現する
3. ボタンを押すと参加者のフィールドにその内容を上書きする

# キャプチャ
![tolymer](https://user-images.githubusercontent.com/445333/83161399-5ccc6000-a143-11ea-9e5a-7c2dc0f98d84.gif)
